### PR TITLE
Take out `create_extensions` toys

### DIFF
--- a/lib/psql_toys/template.rb
+++ b/lib/psql_toys/template.rb
@@ -18,9 +18,12 @@ module PSQLToys
 		on_expand do |template|
 			require_relative 'template/_base'
 
+			require 'gorilla_patch/inflections'
+			using GorillaPatch::Inflections
+
 			tool :database do
-				%w[Create Drop Console Dumps].each do |template_name|
-					require_relative "template/#{template_name.downcase}"
+				%w[Create CreateExtensions Drop Console Dumps].each do |template_name|
+					require_relative "template/#{template_name.underscore}"
 					expand Template.const_get(template_name, false),
 						db_config_proc: template.db_config_proc,
 						db_connection_proc: template.db_connection_proc,

--- a/lib/psql_toys/template/create.rb
+++ b/lib/psql_toys/template/create.rb
@@ -14,9 +14,8 @@ module PSQLToys
 						database = template.db_config[:database]
 
 						sh "createdb -U postgres #{database} -O #{template.db_config[:user]}"
-						template.db_extensions.each do |db_extension|
-							sh "psql -U postgres -c 'CREATE EXTENSION #{db_extension}' #{database}"
-						end
+
+						exec_tool 'db:create_extensions'
 
 						puts "Database #{database} created."
 					end

--- a/lib/psql_toys/template/create_extensions.rb
+++ b/lib/psql_toys/template/create_extensions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module PSQLToys
+	class Template
+		## Define toys for database extensions creation
+		class CreateExtensions < Base
+			on_expand do |template|
+				tool :create_extensions do
+					include :exec, exit_on_nonzero_status: true
+
+					desc 'Create extensions for existing DB'
+
+					to_run do
+						database = template.db_config[:database]
+
+						template.db_extensions.each do |db_extension|
+							sh "psql -U postgres -c 'CREATE EXTENSION #{db_extension}' #{database}"
+						end
+					end
+				end
+			end
+		end
+	end
+end

--- a/psql_toys.gemspec
+++ b/psql_toys.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
 	spec.files = Dir['lib/**/*.rb', 'README.md', 'LICENSE.txt', 'CHANGELOG.md']
 
+	spec.add_runtime_dependency 'gorilla_patch', '> 3', '< 5'
 	spec.add_runtime_dependency 'toys-core', '~> 0.10.0'
 
 	spec.add_development_dependency 'codecov', '~> 0.1.0'


### PR DESCRIPTION
Now it can be used separately, for CI.